### PR TITLE
feat: landing page redesign

### DIFF
--- a/src/components/hero.astro
+++ b/src/components/hero.astro
@@ -2,12 +2,24 @@
 type HeroProps = {
   title: string;
   description: string;
+  goBack?: boolean;
 };
 
-const { title, description } = Astro.props as HeroProps;
+const { title, description, goBack = false } = Astro.props as HeroProps;
 ---
 
 <div class="space-y-3">
+
+  {
+    goBack && (
+      <a href=".." class="text-sm text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1 group">
+        <svg class="w-4 h-4 group-hover:translate-x-0.5 transition-transform rotate-180" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+        </svg>
+        Go back
+      </a>
+    )
+  }
   <h1 class="text-2xl font-bold text-balance">
     {title}
   </h1>

--- a/src/components/post-card.astro
+++ b/src/components/post-card.astro
@@ -1,0 +1,88 @@
+---
+import type { Post } from "../types/posts";
+
+type Props = {
+  post: Post;
+  variant?: "compact" | "full";
+};
+
+const { post, variant = "compact" } = Astro.props;
+const isCompact = variant === "compact";
+---
+
+<a
+  href={post.href}
+  class:list={[
+    "group flex items-start transition-colors",
+    isCompact
+      ? "rounded-lg p-2 -mx-2 hover:bg-muted/40 gap-2"
+      : "rounded-2xl px-4 py-3 hover:bg-muted/40 gap-3",
+  ]}
+>
+  <div
+    class:list={[
+      "rounded-sm mt-0.5 flex items-center justify-center text-muted-foreground opacity-80 group-hover:opacity-100 transition-opacity",
+      isCompact ? "h-4 w-4" : "h-5 w-5",
+    ]}
+  >
+    <svg
+      class:list={[isCompact ? "w-3 h-3" : "w-4 h-4"]}
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9a2 2 0 00-2-2h-2m-4-3H9M7 16h6M7 8h6v4H7V8z"
+      ></path>
+    </svg>
+  </div>
+  <div class="flex-1 min-w-0">
+    <div class="flex items-baseline gap-1.5 flex-wrap">
+      <h3
+        class:list={[
+          "font-medium text-foreground",
+          isCompact ? "text-sm" : "text-base",
+        ]}
+      >
+        {post.title}
+      </h3>
+      <span
+        class:list={[
+          "text-muted-foreground",
+          isCompact ? "text-[10px]" : "text-xs",
+        ]}
+      >
+        {post.date}
+      </span>
+    </div>
+    <p
+      class:list={[
+        "text-muted-foreground mt-0.5",
+        isCompact
+          ? "text-xs leading-relaxed line-clamp-1"
+          : "text-sm leading-relaxed",
+      ]}
+    >
+      {post.description}
+    </p>
+  </div>
+  <svg
+    class:list={[
+      "text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity",
+      isCompact ? "w-3 h-3 mt-0.5" : "w-4 h-4 mt-1",
+    ]}
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      d="M9 5l7 7-7 7"
+    ></path>
+  </svg>
+</a>

--- a/src/components/project-card.astro
+++ b/src/components/project-card.astro
@@ -1,0 +1,92 @@
+---
+import type { Project } from "../types/projects";
+import { getFaviconUrl } from "../lib/utils";
+
+type Props = {
+  project: Project;
+  variant?: "compact" | "full";
+};
+
+const { project, variant = "compact" } = Astro.props;
+const isCompact = variant === "compact";
+---
+
+<a
+  href={project.href}
+  target="_blank"
+  rel="noopener noreferrer"
+  class:list={[
+    "group flex items-start transition-colors",
+    isCompact
+      ? "rounded-lg p-2 -mx-2 hover:bg-muted/40 gap-2"
+      : "rounded-2xl px-4 py-3 hover:bg-muted/40 gap-3",
+  ]}
+>
+  <img
+    src={getFaviconUrl(project.href)}
+    alt={`${project.title} icon`}
+    width="16"
+    height="16"
+    loading="lazy"
+    decoding="async"
+    referrerpolicy="no-referrer"
+    class:list={[
+      "rounded-sm opacity-80 group-hover:opacity-100 transition-opacity",
+      isCompact ? "h-4 w-4 mt-0.5" : "h-5 w-5 mt-0.5",
+    ]}
+    onerror="this.style.display='none'"
+  />
+  <div class="flex-1 min-w-0">
+    {
+      isCompact ? (
+        <>
+          <div class="flex items-baseline gap-1.5 flex-wrap">
+            <h3 class="text-sm font-medium text-foreground">
+              {project.title}
+            </h3>
+            <div class="flex items-center gap-1">
+              {project.tech.slice(0, 2).map((tech) => (
+                <span class="text-[10px] text-muted-foreground/80">{tech}</span>
+              ))}
+            </div>
+          </div>
+          <p class="text-xs text-muted-foreground mt-0.5 leading-relaxed line-clamp-1">
+            {project.description}
+          </p>
+        </>
+      ) : (
+        <>
+          <h3 class="text-base font-medium text-foreground leading-snug">
+            {project.title}
+          </h3>
+          <p class="text-sm text-muted-foreground leading-relaxed mt-1">
+            {project.description}
+          </p>
+          <div class="flex items-center gap-2 mt-2">
+            {project.tech.map((tech) => (
+              <span class="text-xs text-muted-foreground bg-muted/40 rounded-full px-2 py-1">
+                {tech}
+              </span>
+            ))}
+          </div>
+        </>
+      )
+    }
+  </div>
+  <svg
+    class:list={[
+      "text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity",
+      isCompact ? "w-3 h-3 mt-0.5" : "w-4 h-4 mt-1",
+    ]}
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+    ></path>
+  </svg>
+</a>

--- a/src/components/reveal-list.astro
+++ b/src/components/reveal-list.astro
@@ -1,0 +1,64 @@
+---
+type Props = {
+  class?: string;
+};
+
+const { class: className = "" } = Astro.props;
+---
+
+<ul class:list={["space-y-2", className]}>
+  <slot />
+</ul>
+
+<script is:inline>
+  (function () {
+    const reduceMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+    const items = document.querySelectorAll(".reveal");
+
+    if (reduceMotion) {
+      items.forEach((el) => el.classList.add("is-visible"));
+      return;
+    }
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            entry.target.classList.add("is-visible");
+            io.unobserve(entry.target);
+          }
+        }
+      },
+      { threshold: 0.15 },
+    );
+
+    items.forEach((el) => io.observe(el));
+  })();
+</script>
+
+<style is:global>
+  .reveal {
+    opacity: 0;
+    transform: translateY(8px);
+    transition:
+      opacity 400ms ease,
+      transform 400ms ease;
+    transition-delay: var(--delay, 0ms);
+    will-change: opacity, transform;
+  }
+
+  .reveal.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .reveal {
+      opacity: 1;
+      transform: none;
+      transition: none;
+    }
+  }
+</style>

--- a/src/components/section-header.astro
+++ b/src/components/section-header.astro
@@ -1,0 +1,38 @@
+---
+type Props = {
+  title: string;
+  href?: string;
+  linkText?: string;
+};
+
+const { title, href, linkText = "View all" } = Astro.props;
+---
+
+<div class="flex items-center justify-between">
+  <h2 class="text-xs font-medium text-muted-foreground uppercase">
+    {title}
+  </h2>
+  {
+    href && (
+      <a
+        href={href}
+        class="text-sm text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1 group"
+      >
+        {linkText}
+        <svg
+          class="w-4 h-4 group-hover:translate-x-0.5 transition-transform"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M9 5l7 7-7 7"
+          />
+        </svg>
+      </a>
+    )
+  }
+</div>

--- a/src/components/social-links.astro
+++ b/src/components/social-links.astro
@@ -1,8 +1,8 @@
-<div class="flex gap-6 pt-4 text-sm">
+<div class="flex items-center gap-1">
   <a
     href="https://github.com/jralvarenga"
     target="_blank"
-    class="flex items-center gap-2 text-accent hover:underline transition-colors"
+    class="p-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted/40 transition-all"
     aria-label="GitHub"
   >
     <svg
@@ -16,12 +16,11 @@
         d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
         clip-rule="evenodd"></path>
     </svg>
-    <span>GitHub</span>
   </a>
   <a
     href="https://www.linkedin.com/in/jorge-alvarenga-26126b148/"
     target="_blank"
-    class="flex items-center gap-2 text-accent hover:underline transition-colors"
+    class="p-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted/40 transition-all"
     aria-label="LinkedIn"
   >
     <svg
@@ -34,13 +33,12 @@
         d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"
       ></path>
     </svg>
-    <span>LinkedIn</span>
   </a>
   <a
     href="https://x.com/rigo_alvarenga1"
     target="_blank"
-    class="flex items-center gap-2 text-accent hover:underline transition-colors"
-    aria-label="Twitter"
+    class="p-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted/40 transition-all"
+    aria-label="X (Twitter)"
   >
     <svg
       class="w-5 h-5"
@@ -52,11 +50,10 @@
         d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"
       ></path>
     </svg>
-    <span>X.com</span>
   </a>
   <a
     href="mailto:jralvarenga@gmail.com"
-    class="flex items-center gap-2 text-accent hover:underline transition-colors"
+    class="p-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted/40 transition-all"
     aria-label="Email"
   >
     <svg
@@ -73,6 +70,5 @@
         d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
       ></path>
     </svg>
-    <span>Email</span>
   </a>
 </div>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -16,7 +16,7 @@ const defaultTitle = "Jorge Alvarenga";
 const fullTitle = title ? `${title} | ${siteName}` : defaultTitle;
 const metaDescription =
   description ??
-  "Fullstack software developer is my formal title. I build stuff that I need and if it good enough, I share it with everyone.";
+  "Fullstack software engineer is my formal title. I build stuff that I need and if it good enough, I share it with everyone.";
 const ogImage = `${siteUrl}/og-image.png`;
 const twitterImage = `${siteUrl}/og-image.png`;
 ---

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,0 +1,9 @@
+export const posts = [
+  {
+    title: "Coming soon",
+    description:
+      "Writing about experiences building products and experimenting with new tech.",
+    date: "2026",
+    href: "/blog",
+  },
+];

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -1,0 +1,16 @@
+export const projects = [
+  {
+    title: "Budio",
+    description: "Budget planner and expense tracker for web and mobile.",
+    tech: ["Next.js", "Convex", "TypeScript"],
+    href: "https://budio.r1go.dev",
+  },
+  {
+    title: "r1go.dev",
+    description:
+      "Personal site to showcase projects and write about learnings.",
+    tech: ["Astro", "TypeScript"],
+    href: "https://r1go.dev",
+    github: "https://github.com/r1go/r1go.dev",
+  },
+];

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,4 @@
+export function getFaviconUrl(href: string) {
+  const hostname = new URL(href).hostname;
+  return `https://www.google.com/s2/favicons?domain=${hostname}&sz=64`;
+}

--- a/src/pages/about-me.astro
+++ b/src/pages/about-me.astro
@@ -1,0 +1,54 @@
+---
+import Hero from "../components/hero.astro";
+import Layout from "../layouts/Layout.astro";
+import SocialLinks from "../components/social-links.astro";
+---
+
+<Layout>
+  <section class="w-full max-w-2xl text-center space-y-8 text-left">
+    <Hero
+      title="About me"
+      description="Full-stack developer & creative builder"
+      goBack={true}
+    />
+
+    <div class="space-y-6 text-left">
+      <p class="text-base leading-relaxed text-foreground">
+        I build tools and apps to solve problems I run into. When something I
+        build results to be good enough, I share it with everyone so others can
+        use it too and hopefully find it helpful in their own work or daily
+        life.
+      </p>
+
+      <p class="text-base leading-relaxed text-foreground">
+        I have 5+ years of experience in frontend and backend development
+        working with a variety of technologies and frameworks. I focus on
+        building performant and beautiful user experiences, I enjoy building
+        things that feel fast and reliable. I'm currently working at
+        <a
+          href="https://www.cabanenergy.com"
+          target="_blank"
+          class="text-accent underline transition-colors"
+        >
+          Caban Energy
+        </a>
+        as a Frontend Engineer where my stack is React, Next.js, Tailwind and TypeScript.
+      </p>
+
+      <p class="text-base leading-relaxed text-foreground">
+        When I'm not coding, you'll find me exploring new technologies, going to
+        the gym, playing video games or doing something outdoors. You can check <a
+          href="/projects"
+          class="text-accent underline transition-colors"
+          >the projects I've built</a
+        >. See what
+        <a href="/blog" class="text-accent underline transition-colors"
+          >I have written about my experiences and learnings</a
+        >
+        or you can contact me in any social or via email.
+      </p>
+
+      <SocialLinks />
+    </div>
+  </section>
+</Layout>

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -1,6 +1,12 @@
 ---
 import Hero from "../components/hero.astro";
 import Layout from "../layouts/Layout.astro";
+import PostCard from "../components/post-card.astro";
+import RevealList from "../components/reveal-list.astro";
+import type { Post } from "../types/posts";
+// import { posts } from "../lib/posts";
+
+const posts: Post[] = [];
 ---
 
 <Layout
@@ -11,61 +17,23 @@ import Layout from "../layouts/Layout.astro";
     <Hero
       title="Blog"
       description="Writing about my experiences, learnings, and experiments building products."
+      goBack={true}
     />
 
-    <p>Still working on it bro... I'll keep you posted.</p>
+    {
+      posts.length > 0 ? (
+        <RevealList>
+          {posts.map((post, idx) => (
+            <li class="reveal" style={`--delay: ${idx * 70}ms`}>
+              <PostCard post={post} variant="compact" />
+            </li>
+          ))}
+        </RevealList>
+      ) : (
+        <p class="text-muted-foreground">
+          Still working on it... I'll keep you posted.
+        </p>
+      )
+    }
   </section>
 </Layout>
-
-<script is:inline>
-  (function () {
-    const reduceMotion = window.matchMedia(
-      "(prefers-reduced-motion: reduce)",
-    ).matches;
-    const items = document.querySelectorAll(".reveal");
-
-    if (reduceMotion) {
-      items.forEach((el) => el.classList.add("is-visible"));
-      return;
-    }
-
-    const io = new IntersectionObserver(
-      (entries) => {
-        for (const entry of entries) {
-          if (entry.isIntersecting) {
-            entry.target.classList.add("is-visible");
-            io.unobserve(entry.target);
-          }
-        }
-      },
-      { threshold: 0.15 },
-    );
-
-    items.forEach((el) => io.observe(el));
-  })();
-</script>
-
-<style>
-  .reveal {
-    opacity: 0;
-    transform: translateY(10px);
-    transition:
-      opacity 500ms ease,
-      transform 500ms ease;
-    transition-delay: var(--delay, 0ms);
-    will-change: opacity, transform;
-  }
-
-  .reveal.is-visible {
-    opacity: 1;
-    transform: translateY(0);
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .reveal {
-      opacity: 1;
-      transform: none;
-      transition: none;
-    }
-  }
-</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,53 +1,74 @@
 ---
-import Hero from "../components/hero.astro";
 import Layout from "../layouts/Layout.astro";
 import SocialLinks from "../components/social-links.astro";
+import SectionHeader from "../components/section-header.astro";
+import ProjectCard from "../components/project-card.astro";
+import PostCard from "../components/post-card.astro";
+import RevealList from "../components/reveal-list.astro";
+
+import { projects } from "../lib/projects";
+import { posts } from "../lib/posts";
+import Hero from "../components/hero.astro";
 ---
 
 <Layout>
-  <section class="w-full max-w-2xl text-center space-y-8 text-left">
-    <Hero
-      title="Jorge Alvarenga"
-      description="Full-stack developer & creative builder"
-    />
+  <div class="space-y-8">
+    <!-- Hero Section -->
+    <section class="space-y-4">
+      <Hero title="Jorge Alvarenga" description="Full-Stack & Product Developer building tools that solve real problems." />
 
-    <div class="space-y-6 text-left">
+      <SectionHeader title="" href="/about-me" linkText="Read more" />
       <p class="text-base leading-relaxed text-foreground">
-        I build tools and apps to solve problems I run into. When something I
-        build results to be good enough, I share it with everyone so others can
-        use it too and hopefully find it helpful in their own work or daily
-        life.
+        I build stuff that I need and if it good enough, I share it with
+        everyone. With 5+ years of experience in frontend and backend
+        development working with a variety of technologies and frameworks. I
+        focus on building performant and beautiful user experiences.
       </p>
-
-      <p class="text-base leading-relaxed text-foreground">
-        I have 5+ years of experience in frontend and backend development
-        working with a variety of technologies and frameworks. I focus on
-        building performant and beautiful user experiences, I enjoy building
-        things that feel fast and reliable. I'm currently working at
+      <p>
+        Currently working at
         <a
           href="https://www.cabanenergy.com"
           target="_blank"
-          class="text-accent underline transition-colors"
-        >
-          Caban Energy
-        </a>
-        as a Frontend Engineer where my stack is React, Next.js, Tailwind and TypeScript.
+          class="underline decoration-muted-foreground/50 underline-offset-2 hover:decoration-foreground transition-colors"
+          >Caban Energy</a
+        > working with React, Next.js, and TypeScript.
       </p>
+    </section>
 
-      <p class="text-base leading-relaxed text-foreground">
-        When I'm not coding, you'll find me exploring new technologies, going to
-        the gym, playing video games or doing something outdoors. You can check <a
-          href="/projects"
-          class="text-accent underline transition-colors"
-          >the projects I've built</a
-        >. See what
-        <a href="/blog" class="text-accent underline transition-colors"
-          >I have written about my experiences and learnings</a
-        >
-        or you can contact me in any social or via email.
-      </p>
-
+    <!-- Connect Section -->
+    <section class="pt-2">
       <SocialLinks />
-    </div>
-  </section>
+    </section>
+
+    <!-- Projects Section -->
+    <section class="space-y-2">
+      <SectionHeader title="Projects" href="/projects" linkText="Check my projects" />
+      <RevealList>
+        {
+          projects.slice(0, 2).map((project, idx) => (
+            <li class="reveal" style={`--delay: ${idx * 70}ms`}>
+              <ProjectCard project={project} variant="compact" />
+            </li>
+          ))
+        }
+      </RevealList>
+    </section>
+
+    <!-- Writing Section -->
+    <section class="space-y-2">
+      <SectionHeader title="Posts" href="/blog" linkText="See my posts" />
+      <RevealList>
+        {
+          posts.slice(0, 2).map((post, idx) => (
+            <li
+              class="reveal"
+              style={`--delay: ${(projects.length + idx) * 70}ms`}
+            >
+              <PostCard post={post} variant="compact" />
+            </li>
+          ))
+        }
+      </RevealList>
+    </section>
+  </div>
 </Layout>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -1,31 +1,9 @@
 ---
 import Hero from "../components/hero.astro";
 import Layout from "../layouts/Layout.astro";
-import type { Project } from "../types/projects";
-
-function getFaviconUrl(href: string) {
-  const hostname = new URL(href).hostname;
-  // Simple, reliable favicon proxy
-  return `https://www.google.com/s2/favicons?domain=${hostname}&sz=64`;
-}
-
-const projects: Project[] = [
-  {
-    title: "Budio",
-    description:
-      "A budget planner and expense tracker build for the web and comming soon for mobile.",
-    tech: ["Next.js", "Convex", "Polar", "TypeScript"],
-    href: "https://budio.r1go.dev",
-  },
-  {
-    title: "r1go.dev",
-    description:
-      "My personal website to showcase my projects and stuff I write about. Mostly done to experiment with SEO and other web search stuff.",
-    tech: ["Astro", "TypeScript"],
-    href: "https://r1go.dev",
-    github: "https://github.com/r1go/r1go.dev",
-  },
-];
+import ProjectCard from "../components/project-card.astro";
+import RevealList from "../components/reveal-list.astro";
+import { projects } from "../lib/projects";
 ---
 
 <Layout
@@ -35,106 +13,18 @@ const projects: Project[] = [
   <section class="space-y-8">
     <Hero
       title="My projects"
-      description=" Here are some of the things I’ve built. you'll find apps, websites and experiments with differnet technologies and frameworks."
+      description="Here are some of the things I've built. You'll find apps, websites and experiments with different technologies and frameworks."
+      goBack={true}
     />
 
-    <ul class="space-y-3">
+    <RevealList class="space-y-3">
       {
         projects.map((project, idx) => (
           <li class="reveal" style={`--delay: ${idx * 70}ms`}>
-            <a
-              href={project.href}
-              target="_blank"
-              rel="noopener noreferrer"
-              class="group block rounded-2xl hover:shadow-md transition-all duration-450 bg-background/40 backdrop-blur-md px-4 py-2"
-            >
-              <div class="flex items-start justify-between gap-4">
-                <div class="space-y-1">
-                  <div class="flex items-center gap-3">
-                    <img
-                      src={getFaviconUrl(project.href)}
-                      alt={`${project.title} icon`}
-                      width="20"
-                      height="20"
-                      loading="lazy"
-                      decoding="async"
-                      referrerpolicy="no-referrer"
-                      class="h-5 w-5 rounded-sm"
-                      onerror="this.style.display='none'"
-                    />
-                    <h2 class="text-base font-medium text-foreground leading-snug">
-                      {project.title}
-                    </h2>
-                  </div>
-                  <p class="text-sm text-muted-foreground leading-relaxed">
-                    {project.description}
-                  </p>
-                  <div class="flex items-center gap-2">
-                    {project.tech.map((tech) => (
-                      <span class="text-xs text-muted-foreground bg-muted/40 rounded-full px-2 py-1">
-                        {tech}
-                      </span>
-                    ))}
-                  </div>
-                </div>
-              </div>
-            </a>
+            <ProjectCard project={project} variant="full" />
           </li>
         ))
       }
-    </ul>
+    </RevealList>
   </section>
 </Layout>
-
-<script is:inline>
-  (function () {
-    const reduceMotion = window.matchMedia(
-      "(prefers-reduced-motion: reduce)",
-    ).matches;
-    const items = document.querySelectorAll(".reveal");
-
-    if (reduceMotion) {
-      items.forEach((el) => el.classList.add("is-visible"));
-      return;
-    }
-
-    const io = new IntersectionObserver(
-      (entries) => {
-        for (const entry of entries) {
-          if (entry.isIntersecting) {
-            entry.target.classList.add("is-visible");
-            io.unobserve(entry.target);
-          }
-        }
-      },
-      { threshold: 0.15 },
-    );
-
-    items.forEach((el) => io.observe(el));
-  })();
-</script>
-
-<style>
-  .reveal {
-    opacity: 0;
-    transform: translateY(10px);
-    transition:
-      opacity 500ms ease,
-      transform 500ms ease;
-    transition-delay: var(--delay, 0ms);
-    will-change: opacity, transform;
-  }
-
-  .reveal.is-visible {
-    opacity: 1;
-    transform: translateY(0);
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .reveal {
-      opacity: 1;
-      transform: none;
-      transition: none;
-    }
-  }
-</style>

--- a/src/types/posts.d.ts
+++ b/src/types/posts.d.ts
@@ -1,0 +1,6 @@
+export type Post = {
+  title: string;
+  description: string;
+  date: string;
+  href: string;
+};


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Redesigned the landing page with clearer “Projects” and “Posts” sections, new card components, and smooth reveal animations. Added an About Me page and improved page headers with an optional back link.

- **New Features**
  - Added ProjectCard, PostCard, SectionHeader, and RevealList components.
  - Implemented reveal-on-scroll with reduced-motion support.
  - Centralized projects and posts data in src/lib with typed Post.
  - Updated index to show featured projects/posts and revamped SocialLinks UI.
  - Added About Me page using shared components; Hero supports a “Go back” link.

- **Refactors**
  - Moved favicon helper to src/lib/utils.ts.
  - Rebuilt blog and projects pages to reuse components; removed inline scripts/styles.
  - Minor copy and accessibility improvements (aria labels, hover states).

<sup>Written for commit 74314dabb34d055799d33be5275ca25cffa32d0c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

